### PR TITLE
Multiple fixes and enhancements

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -8,10 +8,16 @@ Config = {}
 Config.Notify = "qb-core"                      
 Config.NotifyTitle = "ATM Robbery"
 
+-- % chance the cops are called if using origen_police
+Config.copsCalledChance = 80 -- X/100 = 80%
+
+-- for both Cash & MarkedBills
+Config.randModifier = 2 -- Adjust this to change the skewing; higher values make high amounts less likely
+
 -- For Cash
 Config.UseCash = true           
 Config.MinCash = 500
-Config.MaxCash = 2000
+Config.MaxCash = 20000
 
 -- For MarkedBills
 Config.UseBlackMoney = false
@@ -21,7 +27,7 @@ Config.MinMarkedWorth = 500
 Config.MaxMarkedWorth = 1500
 
 -- Use item
-Config.UseItem = false
+Config.UseItem = true
 Config.BomItem = "weapon_stickybomb"
 
 -- Progressbar timers
@@ -32,6 +38,7 @@ Config.PlaceBompTime = 15000
 -- (5 * 1000) = 5 sec
 -- (300 * 1000) = 5 min
 -- (3600 * 1000) = 1 hour 
+-- Config.CoolDownTime = 5 -- debug value
 Config.CoolDownTime = 3600
 
 -- if true a notify to all players will be send with a message that the atm robbery has been reset...


### PR DESCRIPTION
Added _Config.randModifier_ to create non-linear random value for money
Fixed an issue where _Config.UseItem = true_ would render the script unusable
Created client function _RobAtm_ to clear if loops in _mh-atmrobbery:client:start_
Fixed an issue where the ATM would be set as 'robbed' in _mh-atmrobbery:server:canirobatm_ if trying to rob it without the rob item
Removed useless function _GetDistance_; use simple lua math instead. https://docs.qbcore.org/qbcore-documentation/guides/script-optimization#native-usage
Fixed a double positive return in _mh-atmrobbery:server:hasItem_
Added autonomous origen-police integration. Police will get called if a player tries to rob an ATM